### PR TITLE
add libs to build the example with linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ ifeq ($(OS),darwin)
 LD_EXTRA_FLAGS= -framework Security
 SOBASENAME=libruxc.dylib
 else
+ifeq ($(OS),linux)
+LD_EXTRA_FLAGS= -lpthread -ldl
+endif
+
 SOBASENAME=libruxc.so
 endif
 


### PR DESCRIPTION
The pthread and dl lib seem to be missing to build the example on linux.